### PR TITLE
Feat: Correlation ID 도입 및 log 설정 수정

### DIFF
--- a/app/core/logging_config.py
+++ b/app/core/logging_config.py
@@ -1,9 +1,10 @@
 # https://www.structlog.org/en/stable/standard-library.html
 
 import logging.config
+from typing import Any
 
-import orjson
 import structlog
+from asgi_correlation_id import correlation_id
 
 from app.config import settings
 
@@ -23,80 +24,56 @@ def extract_from_record(_, __, event_dict):
     return event_dict
 
 
-def setup_logging() -> None:
-    if settings.ENVIRONMENT == "local":
-        root_level = "DEBUG"
-        sql_level = "INFO"
-        uvicorn_level = "INFO"
-        format_type = "console"
-    else:
-        root_level = "INFO"
-        sql_level = "WARNING"
-        uvicorn_level = "INFO"
-        format_type = "json"
+def add_correlation(logger: logging.Logger, method_name: str, event_dict: dict[str, Any]) -> dict[str, Any]:
+    if request_id := correlation_id.get():
+        event_dict["request_id"] = request_id
+    return event_dict
 
+
+def setup_logging() -> None:
     message_key = "message"  # 로그 메세지의 key 값 (기본: event)
 
     # 1. 공통 타임스탬프 설정 (ISO 포맷)
     timestamper = structlog.processors.TimeStamper(fmt="iso")
 
-    # 2. 외부 라이브러리(Standard Logging)가 structlog 포맷터로 들어오기 전 거치는 전처리
-    # structlog.configure(processors=[]) 와 최대한 비슷하게 한다
-    foreign_pre_chain = [
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.ExtraAdder(),
-        extract_from_record,  # LogRecord에서 위치 정보 추출
-        timestamper,
-    ]
-    logging.config.dictConfig(
-        {
-            "version": 1,
-            # 설정파일에 없는 로거를 비활성화 시킬지 여부
-            "disable_existing_loggers": False,
-            "formatters": {
-                "console": {
-                    "()": structlog.stdlib.ProcessorFormatter,
-                    "processors": [
-                        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-                        # 콘솔에서는 예외를 줄글로 보는게 편하므로 여기서 변환
-                        structlog.processors.format_exc_info,
-                        structlog.processors.EventRenamer(message_key),
-                        structlog.dev.ConsoleRenderer(colors=True, event_key=message_key),
-                    ],
-                    "foreign_pre_chain": foreign_pre_chain,
-                },
-                "json": {
-                    "()": structlog.stdlib.ProcessorFormatter,
-                    "processors": [
-                        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-                        structlog.processors.dict_tracebacks,
-                        structlog.processors.EventRenamer(message_key),
-                        structlog.processors.JSONRenderer(serializer=orjson.dumps),
-                    ],
-                    "foreign_pre_chain": foreign_pre_chain,
-                },
-            },
-            "handlers": {
-                "default": {
-                    "level": "DEBUG",
-                    "class": "logging.StreamHandler",
-                    "formatter": format_type,
-                },
-            },
-            "loggers": {
-                "": {"handlers": ["default"], "level": root_level, "propagate": True},
-                "uvicorn": {"handlers": ["default"], "level": uvicorn_level, "propagate": False},
-                "uvicorn.error": {"level": uvicorn_level, "propagate": False},
-                "uvicorn.access": {"handlers": ["default"], "level": uvicorn_level, "propagate": False},
-                "fastapi": {"handlers": ["default"], "level": root_level, "propagate": False},
-                "sqlalchemy.engine": {"handlers": ["default"], "level": sql_level, "propagate": False},
-            },
-        }
-    )
+    if settings.ENVIRONMENT == "local":
+        root_level = logging.DEBUG
+        sql_level = logging.INFO
+        uvicorn_level = logging.INFO
+        format_type = "console"
 
-    structlog.configure(
-        processors=[
+        foreign_pre_chain = [
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.ExtraAdder(),
+            timestamper,
+        ]
+
+        structlog_processors = [
+            # 비동기 환경(FastAPI)에서 ContextVars(Request ID 등) 병합
+            structlog.contextvars.merge_contextvars,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            timestamper,
+            structlog.processors.StackInfoRenderer(),
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ]
+
+    else:
+        root_level = logging.INFO
+        sql_level = logging.WARNING
+        uvicorn_level = logging.INFO
+        format_type = "json"
+
+        foreign_pre_chain = [
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.ExtraAdder(),
+            timestamper,
+        ]
+
+        structlog_processors = [
             # 비동기 환경(FastAPI)에서 ContextVars(Request ID 등) 병합
             structlog.contextvars.merge_contextvars,
             # 호출 위치 정보 추가 (스택 오염 전 실행)
@@ -113,11 +90,60 @@ def setup_logging() -> None:
             structlog.stdlib.PositionalArgumentsFormatter(),
             timestamper,
             structlog.processors.StackInfoRenderer(),
-            # 중요: format_exc_info를 여기서 제거함!
-            # 이유는 Formatter 단계(console vs json)에서 각각 다르게 처리하기 위함.
-            # 마지막에 반드시 필요 (std logging의 Formatter로 넘김)
             structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-        ],
+        ]
+
+    # 2. 외부 라이브러리(Standard Logging)가 structlog 포맷터로 들어오기 전 거치는 전처리
+    # structlog.configure(processors=[]) 와 최대한 비슷하게 한다
+
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            # 설정파일에 없는 로거를 비활성화 시킬지 여부
+            "disable_existing_loggers": False,
+            "formatters": {
+                "console": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processors": [
+                        add_correlation,
+                        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                        structlog.processors.EventRenamer(message_key),
+                        structlog.dev.ConsoleRenderer(colors=True, event_key=message_key),
+                    ],
+                    "foreign_pre_chain": foreign_pre_chain,
+                },
+                "json": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processors": [
+                        add_correlation,
+                        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                        structlog.processors.dict_tracebacks,
+                        structlog.processors.EventRenamer(message_key),
+                        structlog.processors.JSONRenderer(),
+                    ],
+                    "foreign_pre_chain": foreign_pre_chain,
+                },
+            },
+            "handlers": {
+                "default": {
+                    "level": "DEBUG",
+                    "class": "logging.StreamHandler",
+                    "formatter": format_type,
+                },
+            },
+            "loggers": {
+                "": {"handlers": ["default"], "level": root_level, "propagate": True},
+                "uvicorn": {"handlers": ["default"], "level": uvicorn_level, "propagate": False},
+                "uvicorn.error": {"handlers": ["default"], "level": uvicorn_level, "propagate": False},
+                "uvicorn.access": {"handlers": ["default"], "level": uvicorn_level, "propagate": False},
+                "fastapi": {"handlers": ["default"], "level": root_level, "propagate": False},
+                "sqlalchemy.engine": {"handlers": ["default"], "level": sql_level, "propagate": False},
+            },
+        }
+    )
+
+    structlog.configure(
+        processors=structlog_processors,
         logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True,

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 
+from asgi_correlation_id import CorrelationIdMiddleware
 from fastapi import FastAPI
 
 from app.api import main
@@ -21,6 +22,9 @@ app = FastAPI(
     redoc_url=None,
     lifespan=lifespan,
 )
+
+# 추적 ID 부여 : 최상단 미들웨어에 존재해야됨(맨 마지막에 add된 것이 최상단)
+app.add_middleware(CorrelationIdMiddleware)
 
 
 app.include_router(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@ description = "Add your description here"
 requires-python = ">=3.14"
 dependencies = [
     "alembic>=1.17.2",
+    "asgi-correlation-id>=4.3.4",
     "fastapi>=0.124.4",
     "jinja2>=3.1.6",
     "nanoid>=2.0.0",
-    "orjson>=3.11.5",
     "psycopg[binary,pool]>=3.3.2",
     "pwdlib[bcrypt]>=0.3.0",
     "pydantic-settings>=2.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -112,6 +112,19 @@ wheels = [
 ]
 
 [[package]]
+name = "asgi-correlation-id"
+version = "4.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/ff/a6538245ac1eaa7733ec6740774e9d5add019e2c63caa29e758c16c0afdd/asgi_correlation_id-4.3.4.tar.gz", hash = "sha256:ea6bc310380373cb9f731dc2e8b2b6fb978a76afe33f7a2384f697b8d6cd811d", size = 20075, upload-time = "2024-10-17T11:44:30.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/ab/6936e2663c47a926e0659437b9333ad87d1ff49b1375d239026e0a268eba/asgi_correlation_id-4.3.4-py3-none-any.whl", hash = "sha256:36ce69b06c7d96b4acb89c7556a4c4f01a972463d3d49c675026cbbd08e9a0a2", size = 15262, upload-time = "2024-10-17T11:44:28.739Z" },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -393,10 +406,10 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "asgi-correlation-id" },
     { name = "fastapi" },
     { name = "jinja2" },
     { name = "nanoid" },
-    { name = "orjson" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pwdlib", extra = ["bcrypt"] },
     { name = "pydantic", extra = ["email"] },
@@ -425,10 +438,10 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.17.2" },
+    { name = "asgi-correlation-id", specifier = ">=4.3.4" },
     { name = "fastapi", specifier = ">=0.124.4" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "nanoid", specifier = ">=2.0.0" },
-    { name = "orjson", specifier = ">=3.11.5" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.3.2" },
     { name = "pwdlib", extras = ["bcrypt"], specifier = ">=0.3.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.12.5" },
@@ -1024,29 +1037,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", hash = "sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef", size = 13307, upload-time = "2024-02-14T23:35:16.286Z" },
-]
-
-[[package]]
-name = "orjson"
-version = "3.11.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/b8/333fdb27840f3bf04022d21b654a35f58e15407183aeb16f3b41aa053446/orjson-3.11.5.tar.gz", hash = "sha256:82393ab47b4fe44ffd0a7659fa9cfaacc717eb617c93cde83795f14af5c2e9d5", size = 5972347, upload-time = "2025-12-06T15:55:39.458Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/60/77d7b839e317ead7bb225d55bb50f7ea75f47afc489c81199befc5435b50/orjson-3.11.5-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:e446a8ea0a4c366ceafc7d97067bfd55292969143b57e3c846d87fc701e797a0", size = 245252, upload-time = "2025-12-06T15:55:01.127Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/aa/d4639163b400f8044cef0fb9aa51b0337be0da3a27187a20d1166e742370/orjson-3.11.5-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:53deb5addae9c22bbe3739298f5f2196afa881ea75944e7720681c7080909a81", size = 129419, upload-time = "2025-12-06T15:55:02.723Z" },
-    { url = "https://files.pythonhosted.org/packages/30/94/9eabf94f2e11c671111139edf5ec410d2f21e6feee717804f7e8872d883f/orjson-3.11.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82cd00d49d6063d2b8791da5d4f9d20539c5951f965e45ccf4e96d33505ce68f", size = 132050, upload-time = "2025-12-06T15:55:03.918Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/c8/ca10f5c5322f341ea9a9f1097e140be17a88f88d1cfdd29df522970d9744/orjson-3.11.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3fd15f9fc8c203aeceff4fda211157fad114dde66e92e24097b3647a08f4ee9e", size = 130370, upload-time = "2025-12-06T15:55:05.173Z" },
-    { url = "https://files.pythonhosted.org/packages/25/d4/e96824476d361ee2edd5c6290ceb8d7edf88d81148a6ce172fc00278ca7f/orjson-3.11.5-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9df95000fbe6777bf9820ae82ab7578e8662051bb5f83d71a28992f539d2cda7", size = 136012, upload-time = "2025-12-06T15:55:06.402Z" },
-    { url = "https://files.pythonhosted.org/packages/85/8e/9bc3423308c425c588903f2d103cfcfe2539e07a25d6522900645a6f257f/orjson-3.11.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92a8d676748fca47ade5bc3da7430ed7767afe51b2f8100e3cd65e151c0eaceb", size = 139809, upload-time = "2025-12-06T15:55:07.656Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/3c/b404e94e0b02a232b957c54643ce68d0268dacb67ac33ffdee24008c8b27/orjson-3.11.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aa0f513be38b40234c77975e68805506cad5d57b3dfd8fe3baa7f4f4051e15b4", size = 137332, upload-time = "2025-12-06T15:55:08.961Z" },
-    { url = "https://files.pythonhosted.org/packages/51/30/cc2d69d5ce0ad9b84811cdf4a0cd5362ac27205a921da524ff42f26d65e0/orjson-3.11.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa1863e75b92891f553b7922ce4ee10ed06db061e104f2b7815de80cdcb135ad", size = 138983, upload-time = "2025-12-06T15:55:10.595Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/87/de3223944a3e297d4707d2fe3b1ffb71437550e165eaf0ca8bbe43ccbcb1/orjson-3.11.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d4be86b58e9ea262617b8ca6251a2f0d63cc132a6da4b5fcc8e0a4128782c829", size = 141069, upload-time = "2025-12-06T15:55:11.832Z" },
-    { url = "https://files.pythonhosted.org/packages/65/30/81d5087ae74be33bcae3ff2d80f5ccaa4a8fedc6d39bf65a427a95b8977f/orjson-3.11.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:b923c1c13fa02084eb38c9c065afd860a5cff58026813319a06949c3af5732ac", size = 413491, upload-time = "2025-12-06T15:55:13.314Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/6f/f6058c21e2fc1efaf918986dbc2da5cd38044f1a2d4b7b91ad17c4acf786/orjson-3.11.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1b6bd351202b2cd987f35a13b5e16471cf4d952b42a73c391cc537974c43ef6d", size = 151375, upload-time = "2025-12-06T15:55:14.715Z" },
-    { url = "https://files.pythonhosted.org/packages/54/92/c6921f17d45e110892899a7a563a925b2273d929959ce2ad89e2525b885b/orjson-3.11.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bb150d529637d541e6af06bbe3d02f5498d628b7f98267ff87647584293ab439", size = 141850, upload-time = "2025-12-06T15:55:15.94Z" },
-    { url = "https://files.pythonhosted.org/packages/88/86/cdecb0140a05e1a477b81f24739da93b25070ee01ce7f7242f44a6437594/orjson-3.11.5-cp314-cp314-win32.whl", hash = "sha256:9cc1e55c884921434a84a0c3dd2699eb9f92e7b441d7f53f3941079ec6ce7499", size = 135278, upload-time = "2025-12-06T15:55:17.202Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/97/b638d69b1e947d24f6109216997e38922d54dcdcdb1b11c18d7efd2d3c59/orjson-3.11.5-cp314-cp314-win_amd64.whl", hash = "sha256:a4f3cb2d874e03bc7767c8f88adaa1a9a05cecea3712649c3b58589ec7317310", size = 133170, upload-time = "2025-12-06T15:55:18.468Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/dd/f4fff4a6fe601b4f8f3ba3aa6da8ac33d17d124491a3b804c662a70e1636/orjson-3.11.5-cp314-cp314-win_arm64.whl", hash = "sha256:38b22f476c351f9a1c43e5b07d8b5a02eb24a6ab8e75f700f7d479d4568346a5", size = 126713, upload-time = "2025-12-06T15:55:19.738Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
#35 

Correlation ID
- 미들웨어에서 부터 고유 ID를 부여받아 모든 로그에 ID가 나오도록 세팅
- 로그에서는 request_id로 찍힘
- 만약 API 요청 시 X-REQUEST-ID 이름의 헤더가 있을 시 해당 ID로 세팅
  - 상세 설정(id 포멧 변경 여부) 가능하여 추후 환경에 따라서 변경 가능

- dev 환경에서 불필요한 filename, funcName, lineno 가 안나오도록 foreign_pre_chain 및  structlog processors 값 환경에 따라서 세팅되도록 수정

- structlog.processors.JSONRenderer serializer orjson.dumps 삭제
  - orjson 사용 시 logger_factory에 structlog.BytesLoggerFactory()를 세팅해야됨
  - 기본 로거에는 세팅할 방법이 없어 기본으로 롤백
  - orjson을 사용안하므로 패키지에서 삭제

- 그외 누락된 uvicorn.error handler 설정 추가